### PR TITLE
overlay: expose the package as an overlay for ease

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -33,6 +33,7 @@
         ./nix/treefmt.nix
         ./nix/checks.nix
         ./nix/devshell.nix
+        ./nix/overlay.nix
       ];
 
       systems = [

--- a/nix/checks.nix
+++ b/nix/checks.nix
@@ -54,6 +54,39 @@
               touch $out
             '';
 
+        # Verify the overlay is valid and exports gp-gui correctly
+        overlay-check =
+          let
+            # Apply the overlay to a test nixpkgs instance
+            testPkgs = pkgs.extend inputs.self.overlays.default;
+          in
+          pkgs.runCommand "verify-overlay" { } ''
+            # Verify the overlay exports gp-gui
+            ${
+              if testPkgs ? gp-gui then
+                ''echo "✓ Overlay exports gp-gui attribute"''
+              else
+                ''
+                  echo "ERROR: Overlay does not export gp-gui attribute"
+                  exit 1
+                ''
+            }
+
+            # Verify gp-gui derivation is valid
+            ${
+              if testPkgs.gp-gui ? outPath then
+                ''echo "✓ gp-gui derivation is valid"''
+              else
+                ''
+                  echo "ERROR: gp-gui derivation is invalid"
+                  exit 1
+                ''
+            }
+
+            echo "✓ Overlay validation complete"
+            touch $out
+          '';
+
         # Rust tests disabled - requires network in nix build
         # Run tests with: nix develop -c cargo test
       };

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: 2025 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  self,
+  ...
+}:
+{
+  flake.overlays.default = final: _prev: {
+    gp-gui =
+      let
+        systemPkgs = self.packages.${final.stdenv.hostPlatform.system} or self.packages.x86_64-linux;
+      in
+      systemPkgs.gp-gui;
+  };
+}


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->

## Related Issue

<!-- Link to related issue(s) if applicable -->

Fixes #

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Dependency update
- [ ] Code refactoring

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [ ] Tested locally with `sudo ./result/bin/gp-gui`
- [ ] Nix build passes: `nix build .#gp-gui`
- [ ] Nix checks pass: `nix flake check`
- [ ] Cargo tests pass: `cargo test`
- [ ] Pre-commit hooks pass

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any additional notes for reviewers -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Flake configuration now loads an additional overlay for package wiring.
  * Added CI/pre‑commit validation to verify the overlay exports the gp-gui package and that the package has a build output.
  * Made gp-gui accessible in a platform-aware way so the package resolves across different system targets.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->